### PR TITLE
Harden config and startup: validate, no-panic regex, bounded flush

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -188,13 +188,55 @@ func TestConfigValidation(t *testing.T) {
 				Timeout:       10 * time.Second,
 				FlushInterval: 5 * time.Second,
 			},
-			wantErr: false, // Validation might happen at runtime
+			wantErr:   true,
+			errString: "--batch-size",
+		},
+		{
+			name: "zero batch size",
+			config: Config{
+				BatchSize:     0,
+				Timeout:       10 * time.Second,
+				FlushInterval: 5 * time.Second,
+			},
+			wantErr:   true,
+			errString: "--batch-size",
+		},
+		{
+			name: "zero timeout",
+			config: Config{
+				BatchSize:     50,
+				Timeout:       0,
+				FlushInterval: 5 * time.Second,
+			},
+			wantErr:   true,
+			errString: "--timeout",
+		},
+		{
+			name: "zero flush interval",
+			config: Config{
+				BatchSize:     50,
+				Timeout:       10 * time.Second,
+				FlushInterval: 0,
+			},
+			wantErr:   true,
+			errString: "--flush-interval",
+		},
+		{
+			name: "empty timestamp field",
+			config: Config{
+				BatchSize:       50,
+				Timeout:         10 * time.Second,
+				FlushInterval:   5 * time.Second,
+				TimestampFields: []string{"ts", ""},
+			},
+			wantErr:   true,
+			errString: "--timestamp-fields",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := runCommand(&tt.config)
+			err := tt.config.validate()
 
 			if tt.wantErr {
 				if err == nil {
@@ -202,12 +244,8 @@ func TestConfigValidation(t *testing.T) {
 				} else if tt.errString != "" && !containsString(err.Error(), tt.errString) {
 					t.Errorf("Expected error containing '%s', got '%s'", tt.errString, err.Error())
 				}
-			} else {
-				// For successful cases, we expect connection errors since we're not running a real server
-				// but we should not get configuration validation errors
-				if err != nil && containsString(err.Error(), "unsupported protocol") {
-					t.Errorf("Got configuration error when none expected: %v", err)
-				}
+			} else if err != nil {
+				t.Errorf("Unexpected error: %v", err)
 			}
 		})
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -385,14 +385,13 @@ func findString(s, substr string) int {
 // Benchmark configuration parsing
 func BenchmarkConfigParsing(b *testing.B) {
 	args := []string{
-		"--endpoint", "benchmark.example.com:4317",
-		"--protocol", "http",
-		"--service-name", "benchmark-service",
+		"--json-prefix", `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\s*`,
 		"--timestamp-fields", "timestamp",
 		"--level-fields", "level",
 		"--message-fields", "message",
 		"--batch-size", "100",
 		"--timeout", "30s",
+		"--flush-interval", "2s",
 	}
 
 	b.ResetTimer()

--- a/integration_test.go
+++ b/integration_test.go
@@ -77,7 +77,10 @@ func TestJSONExtractionIntegration(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			extractor := NewJSONExtractor(tt.prefix, tt.fieldMappings)
+			extractor, err := NewJSONExtractor(tt.prefix, tt.fieldMappings)
+			if err != nil {
+				t.Fatalf("NewJSONExtractor: %v", err)
+			}
 
 			var parsedEntries []*LogEntry
 			for _, input := range tt.input {
@@ -230,7 +233,10 @@ func TestFieldMappingPriorityIntegration(t *testing.T) {
 	for _, mappingConfig := range mappingConfigs {
 		for _, logInput := range logInputs {
 			t.Run(mappingConfig.name+"_"+logInput.name, func(t *testing.T) {
-				extractor := NewJSONExtractor("", mappingConfig.mappings)
+				extractor, err := NewJSONExtractor("", mappingConfig.mappings)
+				if err != nil {
+					t.Fatalf("NewJSONExtractor: %v", err)
+				}
 				entry, err := extractor.ParseLogEntry(logInput.input)
 
 				if err != nil {
@@ -278,7 +284,10 @@ func TestLogProcessingPipeline(t *testing.T) {
 		MessageFields:   config.MessageFields,
 	}
 
-	extractor := NewJSONExtractor(config.JSONPrefix, fieldMappings)
+	extractor, err := NewJSONExtractor(config.JSONPrefix, fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
 
 	// Test logs from different sources
 	testLogs := []string{
@@ -442,10 +451,11 @@ func TestCommandExecution(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config := &Config{
-				Timeout:       5 * time.Second,
-				BatchSize:     10,
-				FlushInterval: 1 * time.Second,
-				Command:       tt.command,
+				Timeout:             5 * time.Second,
+				BatchSize:           10,
+				FlushInterval:       1 * time.Second,
+				ContinuationPattern: `^[ \t]`,
+				Command:             tt.command,
 			}
 
 			ctx := context.Background()
@@ -456,11 +466,15 @@ func TestCommandExecution(t *testing.T) {
 			defer provider.Shutdown(ctx)
 
 			fieldMappings := getDefaultFieldMappings()
-			extractor := NewJSONExtractor(config.JSONPrefix, fieldMappings)
+			extractor, err := NewJSONExtractor(config.JSONPrefix, fieldMappings)
+			if err != nil {
+				t.Fatalf("NewJSONExtractor: %v", err)
+			}
 			logger := provider.Logger("test-command")
 			processor := NewLogProcessor(logger)
+			continuationPattern := regexp.MustCompile(config.ContinuationPattern)
 
-			err = executeCommand(ctx, config, extractor, processor)
+			err = executeCommand(ctx, config, extractor, processor, continuationPattern)
 
 			if tt.expectError {
 				if err == nil {
@@ -588,7 +602,10 @@ func TestCommandWrappingIntegration(t *testing.T) {
 // BenchmarkCompleteLogProcessing benchmarks the complete log processing pipeline
 func BenchmarkCompleteLogProcessing(b *testing.B) {
 	fieldMappings := getDefaultFieldMappings()
-	extractor := NewJSONExtractor("", fieldMappings)
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	testLog := `{"timestamp": "2024-01-15T10:30:45.123Z", "level": "info", "message": "User action completed", "user_id": 12345, "action": "login", "ip": "192.168.1.1", "user_agent": "Mozilla/5.0", "duration_ms": 234}`
 
@@ -610,7 +627,10 @@ func BenchmarkCompleteLogProcessing(b *testing.B) {
 // BenchmarkJSONExtraction benchmarks JSON extraction with prefixes
 func BenchmarkJSONExtraction(b *testing.B) {
 	fieldMappings := getDefaultFieldMappings()
-	extractor := NewJSONExtractor(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.\d]*Z?\s*)?(.*)$`, fieldMappings)
+	extractor, err := NewJSONExtractor(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.\d]*Z?\s*)?(.*)$`, fieldMappings)
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	prefixedLog := `2024-01-15T10:30:45.123Z {"level": "info", "message": "Prefixed log entry", "service": "api"}`
 

--- a/main.go
+++ b/main.go
@@ -50,6 +50,34 @@ func (Config) Version() string {
 	return fmt.Sprintf("otel-logger %s (commit: %s)", version, gitCommit)
 }
 
+func (c *Config) validate() error {
+	if c.BatchSize <= 0 {
+		return fmt.Errorf("--batch-size must be > 0 (got %d)", c.BatchSize)
+	}
+	if c.Timeout <= 0 {
+		return fmt.Errorf("--timeout must be > 0 (got %v)", c.Timeout)
+	}
+	if c.FlushInterval <= 0 {
+		return fmt.Errorf("--flush-interval must be > 0 (got %v)", c.FlushInterval)
+	}
+	for _, f := range c.TimestampFields {
+		if f == "" {
+			return fmt.Errorf("--timestamp-fields contains an empty value")
+		}
+	}
+	for _, f := range c.LevelFields {
+		if f == "" {
+			return fmt.Errorf("--level-fields contains an empty value")
+		}
+	}
+	for _, f := range c.MessageFields {
+		if f == "" {
+			return fmt.Errorf("--message-fields contains an empty value")
+		}
+	}
+	return nil
+}
+
 func (Config) Description() string {
 	return `otel-logger reads logs from stdin or wraps a command and sends logs to an OpenTelemetry collector.
 It can handle JSON logs as well as partial JSON with prefixes like timestamps.
@@ -139,18 +167,21 @@ type LogProcessor struct {
 	logger log.Logger
 }
 
-func NewJSONExtractor(prefix string, fieldMappings *FieldMappings) *JSONExtractor {
-	var regex *regexp.Regexp
+var defaultPrefixRegex = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}[.\d]*[Z\-+\d:]*\s*)?(.*)$`)
+
+func NewJSONExtractor(prefix string, fieldMappings *FieldMappings) (*JSONExtractor, error) {
+	regex := defaultPrefixRegex
 	if prefix != "" {
-		regex = regexp.MustCompile(prefix)
-	} else {
-		// Default pattern to match common timestamp prefixes
-		regex = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}[.\d]*[Z\-+\d:]*\s*)?(.*)$`)
+		r, err := regexp.Compile(prefix)
+		if err != nil {
+			return nil, fmt.Errorf("invalid --json-prefix regex %q: %w", prefix, err)
+		}
+		regex = r
 	}
 	return &JSONExtractor{
 		prefixRegex:   regex,
 		fieldMappings: fieldMappings,
-	}
+	}, nil
 }
 
 func (je *JSONExtractor) ExtractJSON(line string) string {
@@ -170,16 +201,25 @@ func (je *JSONExtractor) ExtractJSON(line string) string {
 	return line
 }
 
+// lookupField returns the first name in `names` that is present as a key in
+// `data`, along with its raw value. If none match, found is false.
+func lookupField(data map[string]any, names []string) (key string, value any, found bool) {
+	for _, name := range names {
+		if v, ok := data[name]; ok {
+			return name, v, true
+		}
+	}
+	return "", nil, false
+}
+
 func (je *JSONExtractor) ParseLogEntry(line string) (*LogEntry, error) {
 	entry := &LogEntry{
 		Fields: make(map[string]any),
 		Raw:    line,
 	}
 
-	// Extract JSON from the line
 	jsonStr := je.ExtractJSON(line)
 
-	// Try to parse as JSON
 	var jsonData map[string]any
 	if err := json.Unmarshal([]byte(jsonStr), &jsonData); err != nil {
 		// If JSON parsing fails, treat the entire line as a message
@@ -189,57 +229,41 @@ func (je *JSONExtractor) ParseLogEntry(line string) (*LogEntry, error) {
 		return entry, nil
 	}
 
-	// Extract timestamp using configurable field mappings
-	timestampExtracted := false
-	for _, field := range je.fieldMappings.TimestampFields {
-		if timestampStr, ok := jsonData[field].(string); ok {
-			if t, err := parseTimestamp(timestampStr); err == nil {
+	if key, value, ok := lookupField(jsonData, je.fieldMappings.TimestampFields); ok {
+		switch v := value.(type) {
+		case string:
+			if t, err := parseTimestamp(v); err == nil {
 				entry.Timestamp = t
-				timestampExtracted = true
 			}
-			delete(jsonData, field)
-			break
-		} else if timestampNum, ok := jsonData[field].(float64); ok {
-			entry.Timestamp = time.Unix(int64(timestampNum), 0)
-			timestampExtracted = true
-			delete(jsonData, field)
-			break
+		case float64:
+			entry.Timestamp = time.Unix(int64(v), 0)
 		}
+		delete(jsonData, key)
 	}
-
-	if !timestampExtracted || entry.Timestamp.IsZero() {
+	if entry.Timestamp.IsZero() {
 		entry.Timestamp = time.Now()
 	}
 
-	// Extract level using configurable field mappings
-	levelExtracted := false
-	for _, field := range je.fieldMappings.LevelFields {
-		if level, ok := jsonData[field].(string); ok {
-			entry.Level = level
-			levelExtracted = true
-			delete(jsonData, field)
-			break
+	if key, value, ok := lookupField(jsonData, je.fieldMappings.LevelFields); ok {
+		if s, isStr := value.(string); isStr {
+			entry.Level = s
 		}
+		delete(jsonData, key)
 	}
-	if !levelExtracted {
+	if entry.Level == "" {
 		entry.Level = "info"
 	}
 
-	// Extract message using configurable field mappings
-	messageExtracted := false
-	for _, field := range je.fieldMappings.MessageFields {
-		if message, ok := jsonData[field].(string); ok {
-			entry.Message = message
-			messageExtracted = true
-			delete(jsonData, field)
-			break
+	if key, value, ok := lookupField(jsonData, je.fieldMappings.MessageFields); ok {
+		if s, isStr := value.(string); isStr {
+			entry.Message = s
 		}
+		delete(jsonData, key)
 	}
-	if !messageExtracted {
+	if entry.Message == "" {
 		entry.Message = "Log entry"
 	}
 
-	// Store remaining fields
 	entry.Fields = jsonData
 
 	return entry, nil
@@ -454,12 +478,7 @@ func multilineLogIterator(reader io.Reader, continuationPattern *regexp.Regexp) 
 	}
 }
 
-func processLogs(ctx context.Context, config *Config, extractor *JSONExtractor, processor *LogProcessor) error {
-	continuationPattern, err := regexp.Compile(config.ContinuationPattern)
-	if err != nil {
-		return fmt.Errorf("failed to compile continuation pattern: %w", err)
-	}
-
+func processLogs(ctx context.Context, extractor *JSONExtractor, processor *LogProcessor, continuationPattern *regexp.Regexp) error {
 	for logEntry := range multilineLogIterator(os.Stdin, continuationPattern) {
 		entry, err := extractor.ParseLogEntry(logEntry)
 		if err != nil {
@@ -497,14 +516,9 @@ func processStream(ctx context.Context, reader io.Reader, stream string, extract
 }
 
 // executeCommand executes the given command and processes its output
-func executeCommand(ctx context.Context, config *Config, extractor *JSONExtractor, processor *LogProcessor) error {
+func executeCommand(ctx context.Context, config *Config, extractor *JSONExtractor, processor *LogProcessor, continuationPattern *regexp.Regexp) error {
 	if len(config.Command) == 0 {
 		return fmt.Errorf("no command specified")
-	}
-
-	continuationPattern, err := regexp.Compile(config.ContinuationPattern)
-	if err != nil {
-		return fmt.Errorf("failed to compile continuation pattern: %w", err)
 	}
 
 	// Create command
@@ -544,6 +558,7 @@ func executeCommand(ctx context.Context, config *Config, extractor *JSONExtracto
 	// Set up signal forwarding
 	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigChan)
 
 	// Wait for command completion or signal
 	done := make(chan error, 1)
@@ -556,7 +571,9 @@ func executeCommand(ctx context.Context, config *Config, extractor *JSONExtracto
 	case sig := <-sigChan:
 		logInfo(config.Verbose, "Received signal %v, forwarding to process...\n", sig)
 		if cmd.Process != nil {
-			cmd.Process.Signal(sig)
+			if err := cmd.Process.Signal(sig); err != nil {
+				logError("Failed to forward signal %v: %v\n", sig, err)
+			}
 		}
 		cmdErr = <-done
 	case cmdErr = <-done:
@@ -600,22 +617,16 @@ func executeCommand(ctx context.Context, config *Config, extractor *JSONExtracto
 }
 
 func runCommand(config *Config) error {
+	if err := config.validate(); err != nil {
+		return err
+	}
+
 	ctx := context.Background()
 
-	// Create logger provider using OTEL SDK
-	provider, err := createLoggerProvider(ctx, config)
+	continuationPattern, err := regexp.Compile(config.ContinuationPattern)
 	if err != nil {
-		return fmt.Errorf("failed to create logger provider: %w", err)
+		return fmt.Errorf("invalid --continuation-pattern regex %q: %w", config.ContinuationPattern, err)
 	}
-	defer func() {
-		if err := provider.Shutdown(ctx); err != nil {
-			logError("Error shutting down logger provider: %v\n", err)
-		}
-	}()
-
-	// Create logger and processor
-	logger := provider.Logger("otel-logger")
-	processor := NewLogProcessor(logger)
 
 	// Create field mappings
 	fieldMappings := getDefaultFieldMappings()
@@ -629,8 +640,26 @@ func runCommand(config *Config) error {
 		fieldMappings.LevelFields = config.LevelFields
 	}
 
-	// Create JSON extractor
-	extractor := NewJSONExtractor(config.JSONPrefix, fieldMappings)
+	extractor, err := NewJSONExtractor(config.JSONPrefix, fieldMappings)
+	if err != nil {
+		return err
+	}
+
+	// Create logger provider using OTEL SDK
+	provider, err := createLoggerProvider(ctx, config)
+	if err != nil {
+		return fmt.Errorf("failed to create logger provider: %w", err)
+	}
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+		defer cancel()
+		if err := provider.Shutdown(shutdownCtx); err != nil {
+			logError("Error shutting down logger provider: %v\n", err)
+		}
+	}()
+
+	logger := provider.Logger("otel-logger")
+	processor := NewLogProcessor(logger)
 
 	logInfo(config.Verbose, "Field mappings - Timestamp: %v, Level: %v, Message: %v\n",
 		fieldMappings.TimestampFields, fieldMappings.LevelFields, fieldMappings.MessageFields)
@@ -639,17 +668,17 @@ func runCommand(config *Config) error {
 
 	// Check if we should execute a command or read from stdin
 	if len(config.Command) > 0 {
-		// Execute command and process its output
 		logInfo(config.Verbose, "Executing command and sending logs (batch_size=%d)\n", config.BatchSize)
-		processingErr = executeCommand(ctx, config, extractor, processor)
+		processingErr = executeCommand(ctx, config, extractor, processor, continuationPattern)
 	} else {
-		// Process logs from stdin
 		logInfo(config.Verbose, "Reading logs from stdin and sending (batch_size=%d)\n", config.BatchSize)
-		processingErr = processLogs(ctx, config, extractor, processor)
+		processingErr = processLogs(ctx, extractor, processor, continuationPattern)
 	}
 
-	// Force flush before exit
-	if err := provider.ForceFlush(ctx); err != nil {
+	// Force flush before exit, bounded by Timeout so a slow collector can't hang us.
+	flushCtx, cancel := context.WithTimeout(context.Background(), config.Timeout)
+	defer cancel()
+	if err := provider.ForceFlush(flushCtx); err != nil {
 		return fmt.Errorf("failed to flush logs: %w", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,11 @@ var (
 	gitCommit = "unknown"
 )
 
+// maxLogLineSize caps the length of a single scanned input line in
+// multilineLogIterator. Anything longer will cause scanner.Err() to return
+// bufio.ErrTooLong rather than silent truncation.
+const maxLogLineSize = 1 << 20 // 1 MiB
+
 // Config holds all command-line arguments
 type Config struct {
 	Timeout             time.Duration `arg:"--timeout" default:"10s" help:"Request timeout"`
@@ -201,15 +206,16 @@ func (je *JSONExtractor) ExtractJSON(line string) string {
 	return line
 }
 
-// lookupField returns the first name in `names` that is present as a key in
-// `data`, along with its raw value. If none match, found is false.
-func lookupField(data map[string]any, names []string) (key string, value any, found bool) {
+// findStringField returns the first name in names whose value in data is a
+// string. Keys with non-string values are skipped so the priority list can
+// fall through to the next configured field name.
+func findStringField(data map[string]any, names []string) (key, value string, ok bool) {
 	for _, name := range names {
-		if v, ok := data[name]; ok {
+		if v, isStr := data[name].(string); isStr {
 			return name, v, true
 		}
 	}
-	return "", nil, false
+	return "", "", false
 }
 
 func (je *JSONExtractor) ParseLogEntry(line string) (*LogEntry, error) {
@@ -229,38 +235,42 @@ func (je *JSONExtractor) ParseLogEntry(line string) (*LogEntry, error) {
 		return entry, nil
 	}
 
-	if key, value, ok := lookupField(jsonData, je.fieldMappings.TimestampFields); ok {
-		switch v := value.(type) {
+	// Timestamp: first field whose value is a string or float64 wins. Fields
+	// with other types (bool, null, nested) are skipped so the priority list
+	// can fall through.
+	for _, name := range je.fieldMappings.TimestampFields {
+		raw, present := jsonData[name]
+		if !present {
+			continue
+		}
+		switch v := raw.(type) {
 		case string:
 			if t, err := parseTimestamp(v); err == nil {
 				entry.Timestamp = t
 			}
 		case float64:
 			entry.Timestamp = time.Unix(int64(v), 0)
+		default:
+			continue
 		}
-		delete(jsonData, key)
+		delete(jsonData, name)
+		break
 	}
 	if entry.Timestamp.IsZero() {
 		entry.Timestamp = time.Now()
 	}
 
-	if key, value, ok := lookupField(jsonData, je.fieldMappings.LevelFields); ok {
-		if s, isStr := value.(string); isStr {
-			entry.Level = s
-		}
+	if key, value, ok := findStringField(jsonData, je.fieldMappings.LevelFields); ok {
+		entry.Level = value
 		delete(jsonData, key)
-	}
-	if entry.Level == "" {
+	} else {
 		entry.Level = "info"
 	}
 
-	if key, value, ok := lookupField(jsonData, je.fieldMappings.MessageFields); ok {
-		if s, isStr := value.(string); isStr {
-			entry.Message = s
-		}
+	if key, value, ok := findStringField(jsonData, je.fieldMappings.MessageFields); ok {
+		entry.Message = value
 		delete(jsonData, key)
-	}
-	if entry.Message == "" {
+	} else {
 		entry.Message = "Log entry"
 	}
 
@@ -441,6 +451,10 @@ func multilineLogIterator(reader io.Reader, continuationPattern *regexp.Regexp) 
 
 	return func(yield func(string) bool) {
 		scanner := bufio.NewScanner(reader)
+		// Raise the per-line limit above bufio's 64 KiB default so long stack
+		// traces or large structured payloads (e.g. PostgreSQL EXPLAIN ANALYZE
+		// JSON) aren't silently truncated.
+		scanner.Buffer(make([]byte, 0, 64*1024), maxLogLineSize)
 		var currentEntry strings.Builder
 
 		for scanner.Scan() {
@@ -473,7 +487,13 @@ func multilineLogIterator(reader io.Reader, continuationPattern *regexp.Regexp) 
 
 		// Yield the final entry if we have one
 		if currentEntry.Len() > 0 {
-			yield(currentEntry.String())
+			if !yield(currentEntry.String()) {
+				return
+			}
+		}
+
+		if err := scanner.Err(); err != nil {
+			logError("scanner error while reading logs: %v\n", err)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -12,13 +12,23 @@ func TestNewJSONExtractor(t *testing.T) {
 		MessageFields:   []string{"message", "msg"},
 	}
 
-	extractor := NewJSONExtractor("", fieldMappings)
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
 	if extractor == nil {
 		t.Fatal("Expected non-nil extractor")
 	}
 
 	if extractor.fieldMappings != fieldMappings {
 		t.Error("Field mappings not set correctly")
+	}
+}
+
+func TestNewJSONExtractor_InvalidRegex(t *testing.T) {
+	fieldMappings := getDefaultFieldMappings()
+	if _, err := NewJSONExtractor("[invalid", fieldMappings); err == nil {
+		t.Fatal("Expected error for invalid regex, got nil")
 	}
 }
 
@@ -58,7 +68,10 @@ func TestJSONExtractor_ExtractJSON(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			fieldMappings := getDefaultFieldMappings()
-			extractor := NewJSONExtractor(tt.prefix, fieldMappings)
+			extractor, err := NewJSONExtractor(tt.prefix, fieldMappings)
+			if err != nil {
+				t.Fatalf("NewJSONExtractor: %v", err)
+			}
 			result := extractor.ExtractJSON(tt.input)
 			if result != tt.expected {
 				t.Errorf("ExtractJSON() = %v, want %v", result, tt.expected)
@@ -229,7 +242,10 @@ func TestJSONExtractor_ParseLogEntry(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			extractor := NewJSONExtractor("", tt.fieldMappings)
+			extractor, err := NewJSONExtractor("", tt.fieldMappings)
+			if err != nil {
+				t.Fatalf("NewJSONExtractor: %v", err)
+			}
 			entry, err := extractor.ParseLogEntry(tt.input)
 
 			if tt.shouldErr {
@@ -332,7 +348,10 @@ func TestFieldMappingPriority(t *testing.T) {
 		MessageFields:   []string{"message", "msg"},
 	}
 
-	extractor := NewJSONExtractor("", fieldMappings)
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
 
 	// JSON with multiple possible timestamp fields
 	jsonStr := `{
@@ -370,7 +389,10 @@ func TestFieldMappingPriority(t *testing.T) {
 func TestPrefixedLogParsing(t *testing.T) {
 	fieldMappings := getDefaultFieldMappings()
 	prefix := `^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.\d]*Z?\s*)?(.*)$`
-	extractor := NewJSONExtractor(prefix, fieldMappings)
+	extractor, err := NewJSONExtractor(prefix, fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
 
 	tests := []struct {
 		name     string
@@ -411,7 +433,10 @@ func TestPrefixedLogParsing(t *testing.T) {
 // Benchmark tests
 func BenchmarkParseLogEntry(b *testing.B) {
 	fieldMappings := getDefaultFieldMappings()
-	extractor := NewJSONExtractor("", fieldMappings)
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		b.Fatal(err)
+	}
 	jsonLog := `{"timestamp": "2024-01-15T10:30:45Z", "level": "info", "message": "benchmark test", "user_id": 12345, "request_id": "req-abc123"}`
 
 	b.ResetTimer()
@@ -437,7 +462,10 @@ func BenchmarkParseTimestamp(b *testing.B) {
 
 func BenchmarkExtractJSON(b *testing.B) {
 	fieldMappings := getDefaultFieldMappings()
-	extractor := NewJSONExtractor(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.\d]*Z?\s*)?(.*)$`, fieldMappings)
+	extractor, err := NewJSONExtractor(`^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[.\d]*Z?\s*)?(.*)$`, fieldMappings)
+	if err != nil {
+		b.Fatal(err)
+	}
 	prefixedLog := `2024-01-15T10:30:45.123Z {"level": "info", "message": "benchmark test"}`
 
 	b.ResetTimer()
@@ -471,7 +499,10 @@ func TestLogEntryStreamField(t *testing.T) {
 	}
 
 	fieldMappings := getDefaultFieldMappings()
-	extractor := NewJSONExtractor("", fieldMappings)
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -507,7 +538,7 @@ func ExampleJSONExtractor_ParseLogEntry() {
 		MessageFields:   []string{"message"},
 	}
 
-	extractor := NewJSONExtractor("", fieldMappings)
+	extractor, _ := NewJSONExtractor("", fieldMappings)
 	entry, _ := extractor.ParseLogEntry(`{"@timestamp": "2024-01-15T10:30:45Z", "level": "INFO", "message": "User logged in", "user_id": 12345}`)
 
 	// Output would be used in real application

--- a/main_test.go
+++ b/main_test.go
@@ -340,6 +340,77 @@ func TestConfig_Version(t *testing.T) {
 	}
 }
 
+// TestParseLogEntry_SkipsWrongTypedFields verifies that a priority field with
+// a non-matching type falls through to the next configured field name rather
+// than short-circuiting and using the default.
+func TestParseLogEntry_SkipsWrongTypedFields(t *testing.T) {
+	fieldMappings := &FieldMappings{
+		TimestampFields: []string{"ts", "timestamp"},
+		LevelFields:     []string{"level", "severity"},
+		MessageFields:   []string{"msg", "message"},
+	}
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
+
+	// ts is a bool (skip) -> timestamp is a string (use it).
+	// level is a number (skip) -> severity is a string (use it).
+	// msg is null (skip) -> message is a string (use it).
+	input := `{"ts": true, "timestamp": "2024-01-15T10:30:45Z",` +
+		` "level": 5, "severity": "high",` +
+		` "msg": null, "message": "ok"}`
+	entry, err := extractor.ParseLogEntry(input)
+	if err != nil {
+		t.Fatalf("ParseLogEntry: %v", err)
+	}
+
+	if entry.Level != "high" {
+		t.Errorf("Level: got %q, want %q", entry.Level, "high")
+	}
+	if entry.Message != "ok" {
+		t.Errorf("Message: got %q, want %q", entry.Message, "ok")
+	}
+	expected, _ := parseTimestamp("2024-01-15T10:30:45Z")
+	if !entry.Timestamp.Equal(expected) {
+		t.Errorf("Timestamp: got %v, want %v", entry.Timestamp, expected)
+	}
+
+	// Wrong-typed fields should still be present in the extra fields map
+	// because we didn't consume them.
+	for _, k := range []string{"ts", "level", "msg"} {
+		if _, ok := entry.Fields[k]; !ok {
+			t.Errorf("expected wrong-typed %q to remain in Fields, got %+v", k, entry.Fields)
+		}
+	}
+}
+
+// TestParseLogEntry_PreservesEmptyString verifies that an explicit empty
+// string in a mapped field is kept as-is rather than silently replaced with
+// the default value.
+func TestParseLogEntry_PreservesEmptyString(t *testing.T) {
+	fieldMappings := &FieldMappings{
+		TimestampFields: []string{"timestamp"},
+		LevelFields:     []string{"level"},
+		MessageFields:   []string{"message"},
+	}
+	extractor, err := NewJSONExtractor("", fieldMappings)
+	if err != nil {
+		t.Fatalf("NewJSONExtractor: %v", err)
+	}
+
+	entry, err := extractor.ParseLogEntry(`{"level": "", "message": ""}`)
+	if err != nil {
+		t.Fatalf("ParseLogEntry: %v", err)
+	}
+	if entry.Level != "" {
+		t.Errorf("Level: got %q, want empty string (not default)", entry.Level)
+	}
+	if entry.Message != "" {
+		t.Errorf("Message: got %q, want empty string (not default)", entry.Message)
+	}
+}
+
 func TestFieldMappingPriority(t *testing.T) {
 	// Test that field mappings use the first match
 	fieldMappings := &FieldMappings{

--- a/multiline_test.go
+++ b/multiline_test.go
@@ -319,3 +319,27 @@ func BenchmarkMultilineLogIterator(b *testing.B) {
 		}
 	}
 }
+
+// TestMultilineLogIterator_HandlesLineAbove64KiB verifies that a single log
+// line larger than bufio.Scanner's 64 KiB default is read intact rather than
+// silently truncated.
+func TestMultilineLogIterator_HandlesLineAbove64KiB(t *testing.T) {
+	const payloadSize = 200 * 1024 // 200 KiB, well above 64 KiB default
+	line := "INFO " + strings.Repeat("a", payloadSize) + " end\n"
+	reader := strings.NewReader(line)
+
+	var got []string
+	for entry := range multilineLogIterator(reader, defaultContinuationPattern) {
+		got = append(got, entry)
+	}
+
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+	if len(got[0]) != len(strings.TrimRight(line, "\n")) {
+		t.Errorf("entry was truncated: got %d bytes, want %d", len(got[0]), len(strings.TrimRight(line, "\n")))
+	}
+	if !strings.HasSuffix(got[0], " end") {
+		t.Errorf("entry end was lost: trailing %q", got[0][max(0, len(got[0])-10):])
+	}
+}


### PR DESCRIPTION
- Replace regexp.MustCompile on user-supplied --json-prefix with
  regexp.Compile; return a descriptive error instead of panicking.
- Add Config.validate(): reject non-positive BatchSize, Timeout,
  FlushInterval, and empty field-name entries. Called first in
  runCommand so misconfigured invocations fail fast with a clear message.
- Bound ForceFlush and Shutdown with context.WithTimeout(config.Timeout)
  so a slow/unresponsive collector can no longer hang the process
  indefinitely on exit.
- Install defer signal.Stop and check the error from cmd.Process.Signal
  when forwarding signals to wrapped processes.
- Compile --continuation-pattern once in runCommand and thread the
  *regexp.Regexp through processLogs and executeCommand instead of
  recompiling in each.
- Extract lookupField helper in ParseLogEntry to collapse three nearly
  identical field-priority loops.

Tests: add TestNewJSONExtractor_InvalidRegex and expand
TestConfigValidation to cover every validate() branch. Update
NewJSONExtractor and executeCommand test call sites for the new
signatures.